### PR TITLE
Update section about custom CSS for TYPO3 backend

### DIFF
--- a/Documentation/UseCases/UseCase1LoadAdditionalStylesheetsToSkinTheBackend/Index.rst
+++ b/Documentation/UseCases/UseCase1LoadAdditionalStylesheetsToSkinTheBackend/Index.rst
@@ -7,14 +7,10 @@ Use case 1: load additional stylesheets to skin the Backend
 Step 1: add following line into ext\_tables.php to register the
 extension ::
 
-   $GLOBALS['TBE_STYLES']['skins'][$_EXTKEY]['name'] = $EXTKEY;
+   $GLOBALS['TBE_STYLES']['skins'][$_EXTKEY]['stylesheetDirectories'][] = 'EXT:my_extension/Resources/Public/Css/Backend/';
 
-Step2: save CSS files with your extension.The name of the CSS files
-does not matter really. More importantly, CSS files need to be saved
-in a specific location to be automatically added onto the Backend:
-
-\- EXT:extension/stylesheets/structure/-
-EXT:extension/stylesheets/visual/
+Step 2: save CSS files with your extension in the configured directory.
+The name of the CSS files does not matter really.
 
 
 ((generated))


### PR DESCRIPTION
The current example in step 1 is not sufficient and the restriction to special directories mentioned in step 2 do not exist any more (checked TYPO3 v9+)